### PR TITLE
support empty metric dimension, allow passing through AWS credentials

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,8 @@ If you call the script every 5 mins, you should specify 360 seconds (6 minutes) 
 Call the script or mon-get-stats command directly if you want to adjust parameters.
 
 history
+1.4 - support empty Dimension parameter, allow passing extra arguments
+(such as AWS credentials) to mon-get-stats
 1.3 - made any "Bytes" unit return in a human readable format - allyunion
 1.2 - arguments changed due to support for multiple regions
 1.1 - added support to check thresholds are below than norma state

--- a/README.txt
+++ b/README.txt
@@ -16,8 +16,8 @@ cfg_file=/etc/nagios/objects/aws.cfg
  - register instance to region = Hostgroup
  - add host name to service definitions as needed
 
-tips: 
-If you call the script every 5 mins, you should better specify 360 sec = 6mins as you might not retrive the last minute data.
+Tips: 
+If you call the script every 5 mins, you should specify 360 seconds (6 minutes) as you might not retrieve the last minute's data.
 Call the script or mon-get-stats command directly if you want to adjust parameters.
 
 history
@@ -26,7 +26,7 @@ history
 1.1 - added support to check thresholds are below than norma state
 1.0 - 1st release
 
-Disclaimer
+Disclaimer:
 
 This script is provided as is without any guarantees or warranty. Use it at your own risk.
 

--- a/check_cloudwatch
+++ b/check_cloudwatch
@@ -25,19 +25,25 @@ usage: $0 <RegionName> <MeasureName> <statistics> <namespace> <dimensions> <peri
  warning     : warning threshold
  critical    : critical threshold
 
-ex: check_cloudwatch us-east-1 CPUUtilization "Average" "AWS/EC2" "InstanceId=i-xxxxxxxx" 360 60 80
+ex: check_cloudwatch us-east-1 CPUUtilization "Average" "AWS/EC2" "InstanceId=i-xxxxxxxx" 360 60 80 [-I AWS_ACCESS_KEY -S AWS_SECRET_KEY]
 EOF
 	exit 3
 fi
 
-source /etc/profile.d/cloudwatch.sh
+if [ -f /etc/profile.d/cloudwatch.sh ]; then
+    source /etc/profile.d/cloudwatch.sh
+fi
 
 starttime=`date -u +%Y-%m-%dT%H:%M:00 -d "$6 sec ago"`
 endtime=`date -u +%Y-%m-%dT%H:%M:00`
 
 # retrieve data by calling API tool
-#RESPONSE=`mon-get-stats "$2" --region "$1" --statistics "$3" --namespace "$4" --dimensions "$5" --show-empty-fields --start-time $starttime --end-time $endtime --period $6` || ( echo UNKOWN: error to call mon-get-status ; exit 3 )
-RESPONSE=`/opt/third-party/amazon/cloudwatch/bin/mon-get-stats "$2" --region "$1" --statistics "$3" --namespace "$4" --dimensions "$5" --start-time $starttime --end-time $endtime --period $6`
+COMMAND="mon-get-stats --region \"$1\" --metric-name \"$2\" --statistics \"$3\" --namespace \"$4\" --start-time $starttime --end-time $endtime --period $6"
+if [[ "$5" != "" ]]; then
+    COMMAND="$COMMAND --dimensions \"$5\""
+fi
+shift 6
+RESPONSE=`$COMMAND $@`
 
 VALUE=`echo $RESPONSE | awk '{print $3}'`
 UNIT=`echo $RESPONSE | awk '{print $4}'`

--- a/check_cloudwatch
+++ b/check_cloudwatch
@@ -42,6 +42,9 @@ COMMAND="mon-get-stats --region \"$1\" --metric-name \"$2\" --statistics \"$3\" 
 if [[ "$5" != "" ]]; then
     COMMAND="$COMMAND --dimensions \"$5\""
 fi
+export MEASURE=$2
+export WARNING=$7
+export CRITICAL=$8
 shift 6
 RESPONSE=`$COMMAND $@`
 
@@ -51,9 +54,6 @@ UNIT=`echo $RESPONSE | awk '{print $4}'`
 # using in-line perl to compare float values
 export VALUE
 export UNIT
-export MEASURE=$2
-export WARNING=$7
-export CRITICAL=$8
 
 perl -e '
 if ($ENV{"VALUE"} eq "")


### PR DESCRIPTION
Thanks for the awesome Nagios script! I made a few things I would call improvements to work for us:
- don't pass along empty --dimension value (necessary to retrieve aggregated metrics)
- allow passing extra arguments to mon-get-data, such as AWS access credentials
- don't fully qualify mon-get-data path, as that is system specific and can be handled better with $PATH
- only source cloudwatch.sh if it actually exists
- minor README.txt cleanup
- remove commented out line (this is in version control, after all)
